### PR TITLE
Select the strictly appropriate version of the pycharm debugger

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-pydevd_pycharm==223.7401.13
+pydevd_pycharm>=223.7401.13
 waiting==1.4.1


### PR DESCRIPTION
Let's remove the strict binding to the pycharm version of the debugger. This will allow the package to be used with more recent versions of pycharm.